### PR TITLE
Incluída nova coluna como PK_ESTADO e antiga alterada para SIGLA_ESTADO

### DIFF
--- a/models/staging/sap/stg_sap__estados.sql
+++ b/models/staging/sap/stg_sap__estados.sql
@@ -1,10 +1,11 @@
 with
     estados as (
         select 
-            stateprovincecode as pk_estado
-            ,countryregioncode as fk_pais
-            ,name as estado
+            cast (stateprovinceid as int) as pk_estado
             ,cast(territoryid as int) fk_territorio
+            ,countryregioncode as fk_pais
+            ,stateprovincecode as sigla_estado
+            ,name as estado
             ,cast(isonlystateprovinceflag as boolean) as flag_provincia_estado
         from {{ source('erp_adventure_works', 'stateprovince') }}
     )


### PR DESCRIPTION
Manutenção no modelo referente à tabela STG_SAP__ESTADOS, incluindo uma nova coluna como chave primária e alterando a antiga para SIGLA_ESTADO. 

OBS: após uma nova análise (depois de aberta a branch), foi concluído que não existe necessidade de alteração no modelo que gera e atualiza os dados da tabela STG_SAP__PAISES.