### PR TITLE
Criação modelo 'stg_sap__cartoes_credito' e alteração no modelo de pedidos de venda

### DIFF
--- a/models/staging/sap/sap.yml
+++ b/models/staging/sap/sap.yml
@@ -14,9 +14,10 @@ sources:
       - name: stateprovince
       - name: address
       - name: countryregion
-      - name: salesorderheader    
+      - name: salesorderheader 
       - name: salesorderdetail
       - name: product
       - name: salesorderheadersalesreason
       - name: salesterritory
       - name: store
+      - name: creditcard

--- a/models/staging/sap/stg_sap__cartoes_credito.sql
+++ b/models/staging/sap/stg_sap__cartoes_credito.sql
@@ -1,0 +1,13 @@
+with
+    cartoes_credito as (
+        select 
+            cast(creditcardid as int) as pk_cartao_credito
+            ,cardtype as tipo_cartao
+            ,cast(cardnumber as numeric(38,0)) as numero_cartao
+            ,cast(expmonth as int) as mes_expiracao
+            ,cast(expyear as int) as ano_expiracao
+        from {{ source('erp_adventure_works', 'creditcard') }}
+    )
+
+select *
+from cartoes_credito

--- a/models/staging/sap/stg_sap__cartoes_credito.yml
+++ b/models/staging/sap/stg_sap__cartoes_credito.yml
@@ -1,0 +1,11 @@
+version: 2
+
+models:
+  - name: stg_sap__cartoes_credito
+    description: Tabela de preparação dos dados brutos dos motivos de venda.
+    columns:
+      - name: pk_cartao_credito
+        description: Identificador de cada motivo de venda
+        data_tests:
+          - unique
+          - not_null  

--- a/models/staging/sap/stg_sap__pedidos_venda.sql
+++ b/models/staging/sap/stg_sap__pedidos_venda.sql
@@ -7,7 +7,7 @@ with
             ,cast(territoryid as int) as fk_territorio
             ,cast(billtoaddressid as int) as fk_endereco_fatura
             ,cast(shiptoaddressid as int) as fk_endereco_entrega
-            ,cast(shipmethodid as int) as fk_metodo_entrega
+            ,cast(creditcardid as int) as fk_cartao_credito
             ,cast(orderdate as date) as data_pedido
             ,cast(duedate as date) as data_validade_pedido
             ,cast(shipdate as date) as data_envio


### PR DESCRIPTION
Realizada criação do modelo que gera e atualiza os dados da tabela 'stg_sap__cartoes_credito'. Também foi alterado o modelo referente aos pedidos de venda, removendo a coluna de ID da entrega e incluindo a coluna de ID do cartão de crédito dos clientes.