### PR TITLE
Manutenção na fórmula de valor negociado líquido

### DIFF
--- a/models/vendas/intermediate/int_vendas_metricas.sql
+++ b/models/vendas/intermediate/int_vendas_metricas.sql
@@ -26,7 +26,7 @@ with
             ,item.preco_unitario
             ,item.perc_desconto
             ,item.preco_unitario * item.quantidade as valor_negociado
-            ,item.preco_unitario * item.quantidade - (1-item.perc_desconto) as valor_negociado_liquido
+            ,item.preco_unitario * item.quantidade * (1-item.perc_desconto) as valor_negociado_liquido
             ,vend.frete / (count(*) over(partition by vend.pk_pedido_venda)) as frete_rateado
             ,vend.status
             ,vend.numero_revisao


### PR DESCRIPTION
Realizada correção na fórmula referente ao cálculo de "Valor Negociado Líquido", pois a informada inicialmente pela área de negócio foi 'unitprice * orderqty - (1-discount)', sendo que o cálculo correto deve ser 'unitprice * orderqty * (1-discount)' .