### PR TITLE
Novos nomes dos schemas padrões do projeto

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -39,14 +39,14 @@ models:
   dbt_adventure_works:
     staging:
       +materialized: table
-      +schema: staging
+      +schema: prd_staging
       sap:
         +materialized: table
 
     vendas:
       intermediate:
         +materialized: table
-        +schema: intermediate
+        +schema: prd_intermediate
       marts:
         +materialized: table
-        +schema: marts
+        +schema: prd_marts


### PR DESCRIPTION
Efetuada a alteração dos nomes dos schemas padrões do projeto (dbt_project), com o objetivo de utilizar o deploy do DBT Cloud com sucesso, uma vez que a configuração de "Role" a qual meu usuário faz parte, não tem permissão de criar/alterar schemas com a nomenclatura Staging e Marts.