### PR TITLE
Alterando coluna que faz o left join com a tabela de pessoas

### DIFF
--- a/models/vendas/intermediate/int_clientes_enriquecida.sql
+++ b/models/vendas/intermediate/int_clientes_enriquecida.sql
@@ -34,7 +34,7 @@ with
             ,pes.flag_email_promocao
             ,pes.flag_nome_estilizado
         from clientes cli
-        left join pessoas pes on cli.pk_cliente = pes.pk_pessoa
+        left join pessoas pes on cli.fk_pessoa = pes.pk_pessoa
         left join territorio_vendas ter on cli.fk_territorio = ter.pk_territorio 
         left join lojas loj on cli.fk_loja = loj.pk_loja
     )


### PR DESCRIPTION
Alteração na coluna utilizada para fazer o left com a tabela de pessoas (stg_sap__pessoas). Estava sendo usada a coluna pk_cliente, sendo que o correto deve ser a utilização da coluna fk_pessoa para retornar os dados corretamente em relação aos clientes.