### PR TITLE
Inclusão do 'schema' padrão para as tabelas seeds

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -50,3 +50,7 @@ models:
       marts:
         +materialized: table
         +schema: prd_marts
+
+seeds:
+  dbt_adventure_works:
+    +schema: prd_intermediate


### PR DESCRIPTION
Realizado ajuste no arquivo 'dbt_project.yml' para padronizar o schema 'SEED' que armazenará as tabelas seeds.